### PR TITLE
Fix issue with finding node id when run in loop

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -252,6 +252,8 @@ class Popup extends HTMLElement {
     }
 
     find_node(uid) {
+		uid = uid.split('.').pop();
+		
         const bits = uid.split(':')
         if (bits.length==1) {
             return app.graph._nodes_by_id[uid]


### PR DESCRIPTION
When i am running this node in loop then first run is fine but every other have issue with finding node by id.

For some reason comfyui add into id other ids, dont know why but have to be something about loop, in my case it look like this: NodeIdOfLoopEndNode.0.0.ImageFilterNodeId

It has nothing to do with subgraph because it use ':'.

Because of it i just remove everything except last part with is node id.